### PR TITLE
MCP tools now use json dump to return a string encoded json

### DIFF
--- a/backend/src/mcp/__init__.py
+++ b/backend/src/mcp/__init__.py
@@ -2,6 +2,7 @@ from warnings import warn
 from mcp.server import FastMCP
 from opentelemetry import trace
 from datetime import datetime, date, timedelta, time
+import json
 
 from src.config import config
 from src.db import schemas, crud
@@ -21,7 +22,7 @@ app = FastMCP()
 
 
 @app.tool()
-async def get_today_sources() -> list[schemas.Source]:
+async def get_today_sources() -> str:
     """
         Retrieves a list of sources that have been published or updated today. This tool helps you quickly access all sources relevant to the current day. These sources may contain possible Indicators of Compromise (IOCs) useful for threat detection and response.
     """
@@ -53,12 +54,13 @@ async def get_today_sources() -> list[schemas.Source]:
         for s in updated_sources:
             all_sources[s.id] = s
         # Convert to schemas.Source
-        return [schemas.Source.model_validate(s) for s in all_sources.values()]
+        return json.dumps([schemas.Source.model_validate(s) for s in all_sources.values()])
 
 @app.tool()
 async def get_last_n_days_sources(
     last_n_days: int = 7
-) -> list[schemas.Source]:
+) -> str:
+
     """
         Retrieves a list of sources that have been published or updated within the last n days. This tool helps you quickly access all sources relevant to the current day. These sources may contain possible Indicators of Compromise (IOCs) useful for threat detection and response.
     """
@@ -91,7 +93,7 @@ async def get_last_n_days_sources(
         for s in updated_sources:
             all_sources[s.id] = s
         # Convert to schemas.Source
-        return [schemas.Source.model_validate(s) for s in all_sources.values()]
+        return json.dumps([schemas.Source.model_validate(s) for s in all_sources.values()])
 
 
 
@@ -99,7 +101,7 @@ async def get_last_n_days_sources(
 async def search_sources(
     query: str,
     limit: int = 10
-) -> list[schemas.SourceWithDistance]:
+) -> str:
     """
         Searches for sources based on a query string. This tool helps you find sources that match specific keywords or phrases, which may contain possible Indicators of Compromise (IOCs) useful for threat detection and response.
     """
@@ -147,4 +149,4 @@ async def search_sources(
         # Apply the limit
         validated_sources = unique_sources[:limit]
 
-        return validated_sources
+        return json.dumps(validated_sources)

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
-
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m max_size=1g inactive=7d use_temp_path=off;
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
@@ -45,6 +45,13 @@ http {
 
         location / {
             proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+        location ^~ /_next/static {
+            proxy_pass http://frontend;
+            proxy_cache STATIC;
+
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       ORACLE_OPENAI_API_KEY: ${OPENAI_API_KEY}
       ORACLE_ENABLE_ALL_TELEMETRY: ${ORACLE_API_ENABLE_ALL_TELEMETRY:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      ORACLE_ENVIRONMENT: ${ORACLE_ENVIRONMENT:-development}
     command:
      - start_api
 
@@ -71,6 +72,7 @@ services:
       ORACLE_OPENAI_API_KEY: ${OPENAI_API_KEY}
       ORACLE_ENABLE_ALL_TELEMETRY: ${ORACLE_MCP_ENABLE_ALL_TELEMETRY:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      ORACLE_ENVIRONMENT: ${ORACLE_ENVIRONMENT:-development}
     command:
       - start_mcp
 
@@ -91,6 +93,7 @@ services:
       ORACLE_PG_PASS: ${POSTGRES_PASSWORD:-postgres}
       ORACLE_PG_DB: ${POSTGRES_DEFAULT_DB:-oracle}
       ORACLE_OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ORACLE_ENVIRONMENT: ${ORACLE_ENVIRONMENT:-development}
     command:
       - start_enrichment
 


### PR DESCRIPTION
This pull request introduces several changes across the backend, configuration, and deployment files. The most significant updates include modifying the return types of several backend functions to JSON strings, adding caching for static files in the Nginx configuration, and introducing a new environment variable in the Docker Compose setup for better environment management.

### Backend Changes:
* Updated the return type of `get_today_sources`, `get_last_n_days_sources`, and `search_sources` functions in `backend/src/mcp/__init__.py` to return JSON strings instead of lists. This ensures consistent serialization when handling responses. [[1]](diffhunk://#diff-d1ebc1b13f59587394ac7c54df87aa1252f3355fbdd5d225d91b16ce5af7da31L24-R25) [[2]](diffhunk://#diff-d1ebc1b13f59587394ac7c54df87aa1252f3355fbdd5d225d91b16ce5af7da31L56-R63) [[3]](diffhunk://#diff-d1ebc1b13f59587394ac7c54df87aa1252f3355fbdd5d225d91b16ce5af7da31L94-R104) [[4]](diffhunk://#diff-d1ebc1b13f59587394ac7c54df87aa1252f3355fbdd5d225d91b16ce5af7da31L150-R152)
* Added `json` import in `backend/src/mcp/__init__.py` to support JSON serialization.

### Configuration Changes:
* Added a `proxy_cache_path` directive to the Nginx configuration (`config/nginx/nginx.conf`) to enable caching for static files, improving performance and reducing server load.
* Introduced a new location block in Nginx (`config/nginx/nginx.conf`) for caching `_next/static` files served by the frontend.

### Deployment Changes:
* Added a new environment variable `ORACLE_ENVIRONMENT` in the `docker-compose.yaml` file for `api`, `mcp`, and `enrichment` services, defaulting to `development`. This facilitates better environment-specific configurations. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R52) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R75) [[3]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R96)