### PR TITLE
Fix return statement in get_last_n_days_sources to remove unnecessary attribute access

### DIFF
--- a/backend/src/mcp/__init__.py
+++ b/backend/src/mcp/__init__.py
@@ -93,7 +93,7 @@ async def get_last_n_days_sources(
         for s in updated_sources:
             all_sources[s.id] = s
         # Convert to schemas.Source
-        return [schemas.Source.model_validate(s).du for s in all_sources.values()]
+        return [schemas.Source.model_validate(s) for s in all_sources.values()]
 
 
 


### PR DESCRIPTION
This pull request includes a minor fix to the `get_last_n_days_sources` function in `backend/src/mcp/__init__.py`. The change removes the `.du` attribute access when validating models, ensuring the function returns a list of `schemas.Source` objects directly.